### PR TITLE
Merge pull request #26 from Naturalclar/feat/rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ React Native Clipboard API for both iOS and Android
 Install the library using either Yarn:
 
 ```
-yarn add @react-native-community/react-native-clipboard
+yarn add @react-native-community/clipboard
 ```
 
 or npm:
 
 ```
-npm install --save @react-native-community/react-native-clipboard
+npm install --save @react-native-community/clipboard
 ```
 
 ## Link
@@ -47,7 +47,7 @@ For android, the package will be linked automatically on build.
 run the following command to link the package:
 
 ```
-$ react-native link @react-native-community/react-native-clipboard
+$ react-native link @react-native-community/clipboard
 ```
 
 or you could follow the instructions to [manually link the project](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking)
@@ -57,7 +57,7 @@ or you could follow the instructions to [manually link the project](https://face
 New React Native comes with `autolinking` feature, which automatically links Native Modules in your project. In order to get it to work, make sure you unlink `Clipboard` first:
 
 ```
-$ react-native unlink @react-native-community/react-native-clipboard
+$ react-native unlink @react-native-community/clipboard
 ```
 
 ## Migrating from the core `react-native` module
@@ -70,14 +70,14 @@ import { Clipboard } from "react-native";
 to:
 
 ```javascript
-import Clipboard from "@react-native-community/react-native-clipboard";
+import Clipboard from "@react-native-community/clipboard";
 ```
 
 ## Usage
 Start by importing the library:
 
 ```javascript
-import Clipboard from "@react-native-community/react-native-clipboard";
+import Clipboard from "@react-native-community/clipboard";
 
 type Props = $ReadOnly<{||}>;
 type State = {|
@@ -104,6 +104,7 @@ export default class App extends React.Component<Props, State> {
 ## Maintainers
 
 * [M.Haris Baig](https://github.com/harisbaig100)
+* [Jesse Katsumata](https://github.com/Naturalclar)
 
 ## Contributing
 
@@ -113,12 +114,12 @@ Please see the [`contributing guide`](/CONTRIBUTING.md).
 
 The library is released under the MIT licence. For more information see [`LICENSE`](/LICENSE).
 
-[build-badge]: https://img.shields.io/circleci/project/github/react-native-community/react-native-clipboard/master.svg?style=flat-square
+[build-badge]: https://img.shields.io/circleci/project/github/react-native-community/clipboard/master.svg?style=flat-square
 [build]: https://circleci.com/gh/react-native-community/react-native-clipboard
-[version-badge]: https://img.shields.io/npm/v/@react-native-community/react-native-clipboard.svg?style=flat-square
-[package]: https://www.npmjs.com/package/@react-native-community/react-native-clipboard
+[version-badge]: https://img.shields.io/npm/v/@react-native-community/clipboard.svg?style=flat-square
+[package]: https://www.npmjs.com/package/@react-native-community/clipboard
 [support-badge]:https://img.shields.io/badge/platforms-android%20|%20ios-lightgrey.svg?style=flat-square
-[license-badge]: https://img.shields.io/npm/l/@react-native-community/react-native-clipboard.svg?style=flat-square
+[license-badge]: https://img.shields.io/npm/l/@react-native-community/clipboard.svg?style=flat-square
 [license]: https://opensource.org/licenses/MIT
 [lean-core-badge]: https://img.shields.io/badge/Lean%20Core-Extracted-brightgreen.svg?style=flat-square
 [lean-core-issue]: https://github.com/facebook/react-native/issues/23313

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @react-native-clipboard
+# @react-native-community/clipboard
 
 [![Build Status][build-badge]][build]
 [![Version][version-badge]][package]

--- a/babel.config.js
+++ b/babel.config.js
@@ -5,7 +5,7 @@ module.exports = {
       'module-resolver',
       {
         alias: {
-          '@react-native-community/react-native-clipboard': './js',
+          '@react-native-community/clipboard': './js',
         },
         cwd: 'babelrc',
       },

--- a/example/App.js
+++ b/example/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {StyleSheet, Text, View, Button, TextInput, Alert} from 'react-native';
-import Clipboard from '@react-native-community/react-native-clipboard';
+import Clipboard from '@react-native-community/clipboard';
 
 type Props = $ReadOnly<{||}>;
 type State = {|

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -249,7 +249,7 @@ DEPENDENCIES:
   - React-RCTVibration (from `../node_modules/react-native/Libraries/Vibration`)
   - ReactCommon/jscallinvoker (from `../node_modules/react-native/ReactCommon`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
-  - "RNCClipboard (from `../node_modules/@react-native-community/react-native-clipboard`)"
+  - "RNCClipboard (from `../node_modules/@react-native-community/clipboard`)"
   - Yoga (from `../node_modules/react-native/ReactCommon/yoga`)
 
 SPEC REPOS:
@@ -306,7 +306,7 @@ EXTERNAL SOURCES:
   ReactCommon:
     :path: "../node_modules/react-native/ReactCommon"
   RNCClipboard:
-    :path: "../node_modules/@react-native-community/react-native-clipboard"
+    :path: "../node_modules/@react-native-community/clipboard"
   Yoga:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 

--- a/example/package.json
+++ b/example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.9.0",
     "react-native": "0.61.5",
-    "@react-native-community/react-native-clipboard": "file:../"
+    "@react-native-community/clipboard": "file:../"
   },
   "devDependencies": {
     "@babel/core": "^7.6.2",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -948,7 +948,7 @@
     eslint-plugin-react-native "3.6.0"
     prettier "1.16.4"
 
-"@react-native-community/react-native-clipboard@file:..":
+"@react-native-community/clipboard@file:..":
   version "1.0.1"
 
 "@types/babel__core@^7.1.0":

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 // CREDITS: This types are based on the original work made by all the people who contributed to @types/react-native
 
-declare module "@react-native-community/react-native-clipboard" {
+declare module "@react-native-community/clipboard" {
   export interface ClipboardStatic {
     /**
      * Get content of string type

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@react-native-community/react-native-clipboard",
-  "version": "1.0.1",
+  "name": "@react-native-community/clipboard",
+  "version": "1.0.0",
   "description": "React Native Clipboard API for both iOS and Android",
   "keywords": [
     "Clipboard",


### PR DESCRIPTION
Renaming the package to `@react-native-community/clipboard` to reduce redundancy
